### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ except ImportError:
 import lazyxml
 
 
-with open('README.rst') as fp:
+with open('README.rst', encoding="utf-8") as fp:
     readme = fp.read()
 
-with open('LICENSE') as fp:
+with open('LICENSE', encoding="utf-8") as fp:
     license = fp.read()
 
 setup(name='lazyxml',


### PR DESCRIPTION
Fix for unicode error message on Windows
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 427: character maps to <undefined>